### PR TITLE
fix(Week.cs): correct the starting day of the week calculation

### DIFF
--- a/src/MySpot.Core/ValueObjects/Week.cs
+++ b/src/MySpot.Core/ValueObjects/Week.cs
@@ -9,7 +9,7 @@ public sealed record Week
     {
         var pastDays = value.DayOfWeek is DayOfWeek.Sunday ? 7 : (int) value.DayOfWeek;
         var remainingDays = 7 - pastDays;
-        From = new Date(value.AddDays(-1 * pastDays));
+        From = new Date(value.AddDays(-1 * pastDays + 1));
         To = new Date(value.AddDays(remainingDays));
     }
 

--- a/tests/MySpot.Tests.Unit/ValueObjects/WeekTests.cs
+++ b/tests/MySpot.Tests.Unit/ValueObjects/WeekTests.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using MySpot.Core.ValueObjects;
+using Shouldly;
+using Xunit;
+
+namespace MySpot.Tests.Unit.ValueObjects;
+
+public class WeekTests
+{
+    [Theory]
+    [InlineData("2023-08-13", "2023-08-07", "2023-08-13")]
+    [InlineData("2023-08-14", "2023-08-14", "2023-08-20")]
+    [InlineData("2023-08-15", "2023-08-14", "2023-08-20")]
+    [InlineData("2023-08-16", "2023-08-14", "2023-08-20")]
+    [InlineData("2023-08-17", "2023-08-14", "2023-08-20")]
+    [InlineData("2023-08-18", "2023-08-14", "2023-08-20")]
+    [InlineData("2023-08-19", "2023-08-14", "2023-08-20")]
+    [InlineData("2023-08-20", "2023-08-14", "2023-08-20")]
+    [InlineData("2023-08-21", "2023-08-21", "2023-08-27")]
+    public void given_datetime_offset_should_create_proper_week(
+        string dateString, string fromDateString, string toDateString)
+    {
+        var dateTime = DateTime.Parse(dateString);
+        
+        var week = new Week(dateTime);
+        
+        week.From.Value.ToString("yyyy-MM-dd").ShouldBe(fromDateString);
+        week.To.Value.ToString("yyyy-MM-dd").ShouldBe(toDateString);
+    }
+}


### PR DESCRIPTION
The previous implementation of the Week class had an off-by-one error in calculating the starting day of the week. This commit corrects the calculation by adding 1 to the pastDays value. Additionally, a comprehensive set of unit tests has been added to ensure the proper behavior of the Week class.